### PR TITLE
Fix "unknown escape character"

### DIFF
--- a/pages/dita/dont_lose_mouse_focus.html
+++ b/pages/dita/dont_lose_mouse_focus.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "DITA: Avoid losing your mouse\'s focus during transform builds"
+title: "DITA: Avoid losing your mouse's focus during transform builds"
 permalink: /dont_lose_mouse_focus/
 date: 2014-12-27 15:16:06.000000000 -08:00
 type: notes_dita


### PR DESCRIPTION
When Jekyll is executed with the `--trace` flag, site emits the following warning:

```text
YAML Exception reading pages/dita/dont_lose_mouse_focus.html: (<unknown>): found unknown escape character while parsing a quoted scalar at line 3 column 8 
```

This PR fixes that issue.