### PR TITLE
Removed the wind speed line from html code sample.

### DIFF
--- a/_docs/using_an_api_like_a_developer/docapis_json_console.md
+++ b/_docs/using_an_api_like_a_developer/docapis_json_console.md
@@ -36,8 +36,7 @@ For this activity, you'll use JavaScript to display the API response on a web pa
           </script>
        </head>
        <body>
-          <h1>Sample Page</h1>
-          wind speed: <span id="windSpeed"></span>
+          <h1>Sample Page</h1>          
        </body>
     </html>
     ```
@@ -79,8 +78,7 @@ For this activity, you'll use JavaScript to display the API response on a web pa
           </script>
        </head>
        <body>
-          <h1>Sample Page</h1>
-          wind speed: <span id="windSpeed"></span>
+          <h1>Sample Page</h1>          
        </body>
     </html>
     ```


### PR DESCRIPTION
This lesson is all about response payload and how to inspect it, whereas the next one tells us how to get data from it and print it on the page. Presumably, we don't print any data from JSON on the page yet, it's the task for the next lesson. However, the line `wind speed: <span id="windSpeed"></span>` in html code sample messes it up a bit, because it already prints wind speed on the page. Besides, it contradicts with the code sample from the next lesson, which initially has an empty html body.  Hence I think this line should not be here.